### PR TITLE
Fix script loading errors when running under java 8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1675110695
+//version: 1675624371
 /*
  DO NOT CHANGE THIS FILE!
  Also, you may replace this file at any time if there is an update available.
@@ -66,7 +66,7 @@ plugins {
     id 'com.diffplug.spotless' version '6.7.2' apply false
     id 'com.modrinth.minotaur' version '2.+' apply false
     id 'com.matthewprenger.cursegradle' version '1.4.0' apply false
-    id 'com.gtnewhorizons.retrofuturagradle' version '1.1.2'
+    id 'com.gtnewhorizons.retrofuturagradle' version '1.1.4'
 }
 boolean settingsupdated = verifySettingsGradle()
 settingsupdated = verifyGitAttributes() || settingsupdated
@@ -520,20 +520,20 @@ dependencies {
         annotationProcessor('org.ow2.asm:asm-debug-all:5.0.3')
         annotationProcessor('com.google.guava:guava:24.1.1-jre')
         annotationProcessor('com.google.code.gson:gson:2.8.6')
-        annotationProcessor('com.gtnewhorizon:gtnhmixins:2.1.10:processor')
+        annotationProcessor('com.gtnewhorizon:gtnhmixins:2.1.12:processor')
         if (usesMixinDebug.toBoolean()) {
             runtimeOnlyNonPublishable('org.jetbrains:intellij-fernflower:1.2.1.16')
         }
     }
     if (usesMixins.toBoolean() || forceEnableMixins.toBoolean()) {
-        implementation('com.gtnewhorizon:gtnhmixins:2.1.10')
+        implementation('com.gtnewhorizon:gtnhmixins:2.1.12')
     }
 }
 
 pluginManager.withPlugin('org.jetbrains.kotlin.kapt') {
     if (usesMixins.toBoolean()) {
         dependencies {
-            kapt('com.gtnewhorizon:gtnhmixins:2.1.10:processor')
+            kapt('com.gtnewhorizon:gtnhmixins:2.1.12:processor')
         }
     }
 }
@@ -633,6 +633,7 @@ tasks.named("processResources", ProcessResources).configure {
 
     if (usesMixins.toBoolean()) {
         from refMap
+        dependsOn("compileJava", "compileScala")
     }
 }
 
@@ -743,6 +744,7 @@ idea {
     module {
         downloadJavadoc = true
         downloadSources = true
+        inheritOutputDirs = true
     }
     project {
         settings {

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,11 +1,9 @@
 // Add your dependencies here
 
 dependencies {
-    compile("com.github.GTNewHorizons:NotEnoughItems:2.2.3-GTNH:dev")
-    compile("com.github.GTNewHorizons:CodeChickenLib:1.1.5.1:dev")
-    compile("com.github.GTNewHorizons:CodeChickenCore:1.1.3:dev")
-    compile("com.github.GTNewHorizons:ForgeMultipart:1.2.7:dev")
-    compileOnly("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-70-GTNH:api") {
+    implementation("com.github.GTNewHorizons:NotEnoughItems:2.3.27-GTNH:dev")
+    implementation("com.github.GTNewHorizons:ForgeMultipart:1.3.1:dev")
+    compileOnly("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-154-GTNH:api") {
         transitive=false
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -59,4 +59,7 @@ containsMixinsAndOrCoreModOnly = false
 # responsibility check the licence and request permission for distribution, if required.
 usesShadowedDependencies = false
 
+# Adds the GTNH maven, CurseMaven, IC2/Player maven, and some more well-known 1.7.10 repositories
+includeWellKnownRepositories = true
+
 customArchiveBaseName = INpureCore

--- a/repositories.gradle
+++ b/repositories.gradle
@@ -1,12 +1,4 @@
 // Add any additional repositiroes for your dependencies here
 
 repositories {
-    mavenCentral()
-    maven {
-        name = "GTNH Maven"
-        url = "http://jenkins.usrv.eu:8081/nexus/content/groups/public/"
-    }
-    maven {
-        url = "https://jitpack.io"
-    }
 }

--- a/src/main/java/info/inpureprojects/core/Scripting/EnumScripting.java
+++ b/src/main/java/info/inpureprojects/core/Scripting/EnumScripting.java
@@ -19,7 +19,7 @@ public enum EnumScripting {
     JAVASCRIPT(".js", (JavaDetection.detectJava()).JavaScript_Callsign, new jsHandler());
 
     static {
-        m = new ScriptEngineManager(EnumScripting.class.getClassLoader());
+        m = new ScriptEngineManager(null);
     }
 
     public static ScriptEngineManager m;
@@ -47,6 +47,10 @@ public enum EnumScripting {
 
     public ScriptEngine getScriptEngine() {
         ScriptEngine engine = m.getEngineByName(this.engine);
+        if (engine == null) {
+            m = new ScriptEngineManager(EnumScripting.class.getClassLoader());
+            engine = m.getEngineByName(this.engine);
+        }
         if (engine == null) {
             // Try any other engine supporting the given extension
             engine = m.getEngineByExtension(StringUtils.removeStart(extension, "."));


### PR DESCRIPTION
Tries the original search path (null classloader) first, before resorting to java 11+ workarounds.
Tested with clean java 8 and lwjgl3ified java 17.

Fixes <https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/12527>